### PR TITLE
Remove 'fs' das dependências

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "author": "iKioshi",
   "license": "MIT",
   "dependencies": {
-    "discord.js": "^11.5.1",
-    "fs": "^0.0.1-security"
+    "discord.js": "^11.5.1"
   },
   "repository": "https://github.com/ikubi/HandlerBasico"
 }


### PR DESCRIPTION
Assim como os módulos `path`, `url` e outros listados na [documentação do Node.JS](https://nodejs.org/docs/latest/api/), o modulo `fs` já vem integrado ao Node.JS, portanto, não é necessária sua instalação. 